### PR TITLE
feat: MailHog を導入する

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -36,3 +36,7 @@ services:
     # Overrides default command so things don't shut down after the process ends.
     #command: /bin/sh -c "while sleep 1000; do :; done"
  
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+        - "8025:8025"

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -59,13 +59,13 @@ COPY ./php/crontabs/ /var/spool/cron/crontabs/
 RUN ln -sfT /dev/stdout /var/log/cron
 CMD ["/usr/bin/supervisord"]
 # sendmail
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  exim4-daemon-light \
-  mailutils \
-  msmtp \
-  && apt-get clean && rm -rf /var/lib/apt/lists/*
-COPY ./php/php/sendmail.ini /usr/local/etc/php/conf.d/
-COPY ./php/exim4/update-exim4.conf.conf /etc/exim4/update-exim4.conf.conf
-RUN service exim4 reload
+#RUN apt-get update && apt-get install -y --no-install-recommends \
+#  exim4-daemon-light \
+#  mailutils \
+#  msmtp \
+#  && apt-get clean && rm -rf /var/lib/apt/lists/*
+#COPY ./php/php/sendmail.ini /usr/local/etc/php/conf.d/
+#COPY ./php/exim4/update-exim4.conf.conf /etc/exim4/update-exim4.conf.conf
+#RUN service exim4 reload
 
 FROM shared AS develop


### PR DESCRIPTION
- [Laravel 6 のメールの絡む開発用に MailHog の Docker コンテナを構築する方法のメモ – oki2a24](https://oki2a24.com/2021/07/25/laravel-6-mailhog-docker-for-development/)

設定 `laravel/.env` の修正点。

```
MAIL_DRIVER=smtp
MAIL_HOST=mailhog
MAIL_PORT=1025
MAIL_USERNAME=user
MAIL_PASSWORD=password
MAIL_ENCRYPTION=null
MAIL_FROM_ADDRESS=null
MAIL_FROM_NAME="${APP_NAME}"
```