### PR TITLE
feat: Dropzone でアップロード前に確認を挟む

### DIFF
--- a/laravel/resources/js/components/BaseDropzone.vue
+++ b/laravel/resources/js/components/BaseDropzone.vue
@@ -29,6 +29,7 @@ export default {
       const myDropzone = new Dropzone(root.value, {
         url: props.url,
         addRemoveLinks: true,
+        autoProcessQueue: false,
         dictDefaultMessage:
           "画像ファイルをここにドロップするか、クリックしてアップロード",
         dictCancelUpload: "アップロードをキャンセル",
@@ -36,6 +37,16 @@ export default {
         ...props.options,
       });
 
+      myDropzone.on("addedfile", (file) => {
+        const confirmed = window.confirm("アップロードしますよ?");
+        if (confirmed) {
+          // myDropzone.processQueue(); では動作しない。
+          // `addedfile` 完了後に `myDropzone.processQueue()` を実行するために setTimeout を使用
+          setTimeout(() => myDropzone.processQueue(), 0);
+        } else {
+          myDropzone.removeFile(file);
+        }
+      });
       myDropzone.on("success", (file, response) => {
         emit("onSuccess", file, response);
         setTimeout(() => myDropzone.removeFile(file), 10000);


### PR DESCRIPTION
- [Vue.js 3 で Dropzone をラップした SFC その3 。ファイルアップロード前に確認操作を挟む – oki2a24](https://oki2a24.com/2021/08/02/vue-js-3-dropzone-sfc-3-confirm-before-upload/)